### PR TITLE
Add a step to update VitaShell to v1.82 or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ Custom Firmware 3.65 HENkaku Ensō is a port of [henkaku](https://github.com/hen
 - Some applications may not work on the new firmware and need to be ported.
 
 ## Instructions
-1) Download [updater.vpk](https://github.com/TheOfficialFloW/update365/releases/download/v1.0/updater.vpk) and [PSP2UPDAT.PUP](https://github.com/TheOfficialFloW/update365/releases/download/v1.0/PSP2UPDAT.PUP).
-2) If you are on a firmware below 3.60, update to 3.60 and install [henkaku](https://henkaku.xyz/). Then you can skip to 4.
-3) If you are already using 3.60 HENkaku (Enso), uninstall all plugins and uninstall the enso patch. It is recommended to first unlink the Memory Card in `HENkaku Settings` before you uninstall, so that your Memory Card won't be restricted afterwards due to the spoofed version at `ux0:id.dat`. Uninstalling all plugins and the enso patch is extremely important, as they can interfere with the update process if enabled (the updater will notice you in case you have not uninstalled them correctly).
-4) Install `updater.vpk` using [VitaShell](https://github.com/TheOfficialFloW/VitaShell/releases) and put the `PSP2UPDAT.PUP` file at `ux0:app/UPDATE365/PSP2UPDAT.PUP`.
-5) Reboot your device, start HENkaku and directly launch the updater, without launching anything else before like VitaShell or Adrenaline (since they start kernel modules). Also make sure that your battery is at least at 50%.
-6) Follow the instructions on screen and enjoy the update process.
-7) When the updater finishes flashing the new firmware, custom modules will be written to `vs0:tai` and the bootloader hack injected to the eMMC. You should now be on 3.65 HENkaku Ensō.
+1) Update [VitaShell](https://github.com/TheOfficialFloW/VitaShell/releases) to v1.82 or later
+2) Download [updater.vpk](https://github.com/TheOfficialFloW/update365/releases/download/v1.0/updater.vpk) and [PSP2UPDAT.PUP](https://github.com/TheOfficialFloW/update365/releases/download/v1.0/PSP2UPDAT.PUP).
+3) If you are on a firmware below 3.60, update to 3.60 and install [henkaku](https://henkaku.xyz/). Then you can skip to 4.
+4) If you are already using 3.60 HENkaku (Enso), uninstall all plugins and uninstall the enso patch. It is recommended to first unlink the Memory Card in `HENkaku Settings` before you uninstall, so that your Memory Card won't be restricted afterwards due to the spoofed version at `ux0:id.dat`. Uninstalling all plugins and the enso patch is extremely important, as they can interfere with the update process if enabled (the updater will notice you in case you have not uninstalled them correctly).
+5) Install `updater.vpk` using [VitaShell](https://github.com/TheOfficialFloW/VitaShell/releases) and put the `PSP2UPDAT.PUP` file at `ux0:app/UPDATE365/PSP2UPDAT.PUP`.
+6) Reboot your device, start HENkaku and directly launch the updater, without launching anything else before like VitaShell or Adrenaline (since they start kernel modules). Also make sure that your battery is at least at 50%.
+7) Follow the instructions on screen and enjoy the update process.
+8) When the updater finishes flashing the new firmware, custom modules will be written to `vs0:tai` and the bootloader hack injected to the eMMC. You should now be on 3.65 HENkaku Ensō.
 
 ## FAQ
 - "Are Adrenaline, DownloadEnabler, NoNpDrm and SD2VITA compatible on 3.65?" - Yes they have all been updated and are available under my repositories.


### PR DESCRIPTION
The auto-update feature of VitaShell may not work because of GitHub recently removing TLS v1/v1.1 support (https://githubengineering.com/crypto-deprecation-notice/), or users may not have their devices connected online to see the update notification. So some users may update to 3.65 w/ enso while accidentally forgetting to update VitaShell too.